### PR TITLE
Ignore local .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .history
 .vscode
+\.ruby-version


### PR DESCRIPTION
Useful for configuring local rb environment for running Jekyll.