### PR TITLE
Attribute the June 2017 #uPortal Slack summary post to its author

### DIFF
--- a/_posts/uportal/2017-07-05-uportal-slack-summary.md
+++ b/_posts/uportal/2017-07-05-uportal-slack-summary.md
@@ -41,17 +41,19 @@ Conversation highlights include:
 
 I have [concerns about the openness properties of Slack as implemented by Apereo][open@ 2017-06-15]. You can't access it or read its logs anonymously; it's not Google search indexed. Only the most recent ten thousand messages are available, so in practice this means logs are unavailable older than about a month back.
 
-Summarizing the conversations in this anonymously, publicly accessible and Google indexable context somewhat mitigates these problems.
+Summarizing the conversations in this anonymously, publicly accessible and Google indexable context somewhat mitigates these problems. But not necessarily other problems that make [email list communications preferable in open source projects].
 
 Arguably, all of the conversations held in the `#uportal` Slack channel this month could have been held via email on `uportal-dev@` or `uportal-user@` email lists additionally or instead. Some relevant email list threads are linked above.
 
 -[Andrew](https://apetro.ghost.io)
 
 [@uPortal]: https://twitter.com/uPortal
+[Accessibility across Apereo thread on uportal-user@]: https://groups.google.com/a/apereo.org/d/topic/uportal-user/KQbBMtUHHFY/discussion
 [Accessibility group]: https://groups.google.com/a/apereo.org/forum/#!forum/accessibility
 [another uportal-dev@ thread on overlays directory renaming]: https://groups.google.com/a/apereo.org/d/topic/uportal-dev/uaeYARDVRZY/discussion
 [browser support for Polymer]: https://www.polymer-project.org/2.0/docs/browsers
 [conversational UI example]: http://azumbrunnen.me/
+[email list communications preferable in open source projects]: https://dave.cheney.net/2017/04/11/why-slack-is-inappropriate-for-open-source-communications
 [gitinspector]: https://github.com/ejwa/gitinspector
 [i18next]: https://www.i18next.com/
 [jekyll-multiple-languages-plugin]: https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin
@@ -72,4 +74,3 @@ Arguably, all of the conversations held in the `#uportal` Slack channel this mon
 [uPortal-start PR 10]: https://github.com/Jasig/uPortal-start/pull/10
 [uPortal-start PR 6]: https://github.com/Jasig/uPortal-start/pull/6
 [uPortal-start PR 8]: https://github.com/Jasig/uPortal-start/pull/8
-[Accessibility across Apereo thread on uportal-user@]: https://groups.google.com/a/apereo.org/d/topic/uportal-user/KQbBMtUHHFY/discussion

--- a/_posts/uportal/2017-07-05-uportal-slack-summary.md
+++ b/_posts/uportal/2017-07-05-uportal-slack-summary.md
@@ -53,7 +53,7 @@ Arguably, all of the conversations held in the `#uportal` Slack channel this mon
 [gitinspector]: https://github.com/ejwa/gitinspector
 [i18next]: https://www.i18next.com/
 [jekyll-multiple-languages-plugin]: https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin
-[myday cloud based portal]: https://www.collabco.co.uk/features/dashboards/
+[myday cloud-based portal]: https://www.collabco.co.uk/features/dashboards/
 [open@ 2017-06-15]: https://groups.google.com/a/apereo.org/d/msg/open/cbk9NLb43LQ/btRpD_09AwAJ
 [Portal?! uPortal! What is this Béchamel]: https://cousquer.github.io/apereo2017/
 [ReactJS portlet with i18n support]: https://github.com/bpowell/i18n-react-portlet

--- a/_posts/uportal/2017-07-05-uportal-slack-summary.md
+++ b/_posts/uportal/2017-07-05-uportal-slack-summary.md
@@ -45,6 +45,8 @@ Summarizing the conversations in this anonymously, publicly accessible and Googl
 
 Arguably, all of the conversations held in the `#uportal` Slack channel this month could have been held via email on `uportal-dev@` or `uportal-user@` email lists additionally or instead. Some relevant email list threads are linked above.
 
+-[Andrew](https://apetro.ghost.io)
+
 [@uPortal]: https://twitter.com/uPortal
 [Accessibility group]: https://groups.google.com/a/apereo.org/forum/#!forum/accessibility
 [another uportal-dev@ thread on overlays directory renaming]: https://groups.google.com/a/apereo.org/d/topic/uportal-dev/uaeYARDVRZY/discussion

--- a/_posts/uportal/2017-07-05-uportal-slack-summary.md
+++ b/_posts/uportal/2017-07-05-uportal-slack-summary.md
@@ -22,7 +22,7 @@ In June 2017, 11 people participated substantially in conversation in the [slack
 
 Conversation highlights include:
 
-+ Aaron Grant's [uportal_commit_stats] script and its findings about uPortal contributions. [gitinspector] might also be useful for uPortal-related Git history analysis.
++ Aaron Grant's [uportal_commit_stats] script and findings about uPortal contributions. [gitinspector] might also be useful for uPortal-related Git history analysis.
 + Internationalization of documentation stored in Git. What Symfony does in its [primary][symfony-docs] and [French-translation][symfony-docs-fr] documentation. (Separate repos.). Alternatively, the [jekyll-multiple-languages-plugin] . Example [ReactJS portlet with i18n support] based in [i18next].
 + Sharing resources from the Open Apereo 2017 conference, including [Portal?! uPortal! What is this Béchamel], [Speeding up uPortal with ReactJS], [two-hard-problems]. (Cf. [uportal-dev@ thread re conference artifacts].)
 + Encouraging interest in the new [Accessibility group]. (Cf. [Accessibility Across Apereo thread on uportal-user@])
@@ -39,7 +39,7 @@ Conversation highlights include:
 
 ## On Slack
 
-I have some [concerns about the openness properties of Slack as implemented by Apereo][open@ 2017-06-15]. You can't read its logs anonymously; you have to log in to access it and you can't come across its content via a Google search. Only the most recent ten thousand messages are available, so in practice this means logs are lost about a month back.
+I have [concerns about the openness properties of Slack as implemented by Apereo][open@ 2017-06-15]. You can't access it or read its logs anonymously; it's not Google search indexed. Only the most recent ten thousand messages are available, so in practice this means logs are unavailable older than about a month back.
 
 Summarizing the conversations in this anonymously, publicly accessible and Google indexable context somewhat mitigates these problems.
 


### PR DESCRIPTION
The June 2017 uPortal Slack summary post uses first person but it's left unclear who the first person is. These edits would attribute the post to its author (me).

Also 

+ notes additional concern about asynchronous chat communications in open source projects, vs using email lists
+ fixes a broken reference link.
+ trivial copy edits for brevity.