### PR TITLE
fix(description): participants, not members

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title:       Apereo Foundation Github Blog
 email:       info@apereo.org
 author:      Apereo Foundation
-description: "This is a blog managed and edited by the Apereo Foundation members. It is typically used to post project updates, announce news, etc."
+description: "This is a blog managed and edited by the Apereo Foundation participants. It is typically used to post project updates, announce news, etc."
 baseurl:     "https://apereo.github.io"
 date_format: "%b %-d, %Y"
 url:         "https://apereo.github.io"


### PR DESCRIPTION
This:

> This is a blog managed and edited by the Apereo Foundation **participants**.

Rather than:

> This is a blog managed and edited by the Apereo Foundation **members**.

Formally, Apereo is a membership organization with (primarily) paying institutional members and (incidentally) paying individual members. In practice the managers and editors of this blog probably aren't formally Apereo members and we wouldn't gate management and editorial participation, and certainly not contribution, on Apereo membership.