### PR TITLE
Correct link to Apereo twitter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ facebook_comments_number: 10
 github_username: apereo
 bitbucket_username:
 stackoverflow_id:
-twitter_username: ApereoOrg
+twitter_username: Apereo
 skype_username:
 steam_nickname:
 google_plus_id:

--- a/_includes/post_footer.html
+++ b/_includes/post_footer.html
@@ -2,6 +2,6 @@
   <!-- <img src="{{ site.baseurl }}/images/me.jpeg" alt="John Otander" class="avatar" /> -->
 
   <p>
-    Follow Apereo on <a href="https://twitter.com/ApereoOrg">Twitter</a>.
+    Follow Apereo on <a href="https://twitter.com/{{ site.twitter_username }}">Twitter</a>.
   </p>
 </div>


### PR DESCRIPTION
https://twitter.com/ApereoOrg does not exist.
https://twitter.com/Apereo is the active twitter.