### PR TITLE
feat(ads): rm codesponsor ad

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,9 +6,6 @@
     </small>
   </div>
 
-  <div id="code-sponsor-widget"></div>
-  <script type="text/javascript"
-          src="https://app.codesponsor.io/scripts/ldVcx4GOV0hfdH1r4Ir6UQ?theme=light"></script>
           
 </footer>
 {% if site.enable_anchorjs %}<!-- AnchorJS -->


### PR DESCRIPTION
I don't think Apereo websites, including `apereo.github.io`, should be showing third party ads. 

If we are going to show third party ads on Apereo websites, I think we need more discussion about this decision before doing it.

(Partially reverts 0863e60f471a32ad8097e08a74052d1186d7dbd0 "updated blog for cas 5 rc4 news; added extra footer").