### PR TITLE
Reflect moved `uPortal home` repos

### DIFF
--- a/_posts/uportal/2016-09-15-myuw-build-now-and-future.md
+++ b/_posts/uportal/2016-09-15-myuw-build-now-and-future.md
@@ -9,6 +9,7 @@ During the most recent uPortal development meeting we were discussing how uPorta
 
 Edits: 
 + adjusted to reflect the new name `uPortal app framework` and new repository location for what was previously known as `uw-frame`
++ adjusted to reflect the new name `uPortal home` and new repository location for what was previously known as `AngularJS-portal`
 
 ## The Now
 
@@ -41,7 +42,7 @@ After the ear build runs with the test ear, we then can deliver it to test. We h
 
 ## Looking ahead to where we would like to go
 
-We like our current setup but we would like to improve on a few things. Here is our wish list. First we would love to stop having to fork uPortal to get our own skin and configuration (using the alternative angularjs-portal front end). If we could do a Docker overlay process that could be nice.
+We like our current setup but we would like to improve on a few things. Here is our wish list. First we would love to stop having to fork uPortal to get our own skin and configuration (using the alternative `uPortal home` front end). If we could do a Docker overlay process that could be nice.
 
 We would also like to have it possible to ship the content of the webapp directory instead of depending on a volume mount from the host. In order to accomplish that we need to get rid of the hard coded passwords in the configuration files. We are looking toward using [VaultProject](https://www.vaultproject.io/) for that. This would have the sided bonus of removing the complexity of maven overlays. During startup vault could go fetch the configuration for that given environment.
 

--- a/_posts/uportal/2016-09-15-myuw-build-now-and-future.md
+++ b/_posts/uportal/2016-09-15-myuw-build-now-and-future.md
@@ -7,6 +7,9 @@ tags:       [uPortal]
 
 During the most recent uPortal development meeting we were discussing how uPortal building and deployment currently works and ought to work. It came up that other campuses are checking out the project on each server, building the ear, and shipping it to Tomcat. UW does not take that approach and we thought it may be helpful to articulate what we do to maybe help steer the next generation uPortal project (aka uPortal 5).
 
+Edits: 
++ adjusted to reflect the new name `uPortal app framework` and new repository location for what was previously known as `uw-frame`
+
 ## The Now
 
 There are many pieces of technology that the UW uses. Here are the components and some other definitions that will be used in this technical document:
@@ -44,7 +47,7 @@ We would also like to have it possible to ship the content of the webapp directo
 
 It could also be interesting to be able to download a docker artifact containing a configured uPortal from docker hub. The only downside is we would like to be able to control the versions of Java and Tomcat. However, if we updated this often we could be alright with relieving that control.
 
-A single Docker container running a big JVM can be painful to scale. We would like to look into splitting out our webapps into many docker containers so we can scale only the things that need scaling. A great example of that is the wave of students who need to get to our campus course guide (which is currently a portlet). If we wanted to increase the bandwidth of that one portlet, we would need to stand up another 6GB JVM. We are migrating that application to a normal webapp so this is possible. It will still have a MyUW presence, but just through widgets and links. It will have the added bonus to look like it is part of the MyUW experience using shared angular components from [uw-frame](https://github.com/UW-Madison-DoIT/uw-frame).
+A single Docker container running a big JVM can be painful to scale. We would like to look into splitting out our webapps into many docker containers so we can scale only the things that need scaling. A great example of that is the wave of students who need to get to our campus course guide (which is currently a portlet). If we wanted to increase the bandwidth of that one portlet, we would need to stand up another 6GB JVM. We are migrating that application to a normal webapp so this is possible. It will still have a MyUW presence, but just through widgets and links. It will have the added bonus to look like it is part of the MyUW experience using shared angular components from [uPortal app framework](https://github.com/uPortal-project/uportal-app-framework).
 
 We are also looking toward running on AWS, but this is in the very early stages.
 

--- a/_posts/uportal/2016-10-25-myuw-release.md
+++ b/_posts/uportal/2016-10-25-myuw-release.md
@@ -7,9 +7,13 @@ tags:       [uPortal]
 
 Today MyUW promoted a new release to production. This post highlights some aspects of this.
 
+Edits:
+
++ Updated to reflect new name `uPortal home` and new git repository location for what was once called `AngularJS-portal`
+
 ## This release
 
-[This release](https://kb.wisc.edu/myuw/page.php?id=68015) upgraded MyUW to `AngularJS-portal` [v5.4.1](https://github.com/UW-Madison-DoIT/angularjs-portal/releases/tag/angularjs-portal-parent-5.4.1) from [v5.2.4](https://github.com/UW-Madison-DoIT/angularjs-portal/releases/tag/angularjs-portal-parent-5.2.4).
+[This release](https://kb.wisc.edu/myuw/page.php?id=68015) upgraded MyUW to `uPortal home` [v5.4.1](https://github.com/uPortal-project/uportal-home/releases/tag/angularjs-portal-parent-5.4.1) from [v5.2.4](https://github.com/uPortal-project/uportal-home/releases/tag/angularjs-portal-parent-5.2.4).
 
 ## Highlights for Apereo community
 
@@ -19,7 +23,7 @@ Today MyUW promoted a new release to production. This post highlights some aspec
 ### Lessons to learn
 
 + Semantic versioning is important. We had a hiccup in this release because a `rest-proxy` change wasn't backwards-compatible as regards `endpoints.properties`. In retrospect, the properties file configuring this product *is* its API so breaking changes would be better signaled with a `MAJOR` version change (and avoided when not strictly necessary).
-+ Deep linking is important, enabling better communication about and leverage of content in your portal. This release fixed support for deep links into AngularJS-portal content.
++ Deep linking is important, enabling better communication about and leverage of content in your portal. This release fixed support for deep links into `uPortal home` content.
 
 
 ## Calls to action
@@ -39,18 +43,18 @@ You don't have to adopt everything MyUW has adopted to find something that would
 
 Likewise, maybe you've got some microservice projects and products we could be collaborating on if we knew about them.
 
-### Adopt angularJS-portal. 
+### Adopt `uPortal home`. 
 
-[AngularJS-portal][] is a modern user experience layer to plop down in front of your uPortal. 
+[uPortal home][] is a modern user experience layer to plop down in front of your uPortal. 
 
-* You don't have to adopt it all at once, for everyone, for every user experience in your portal. MyUW variously implemented it as opt-in, opt-out, at certain hostnames, for certain identities, for certain experiences within MyUW. It's been a long walk using the new technology for more and more experiences, and we're still using the traditional uPortal rendering pipeline to render some maximized portlet user experiences. AngularJS-portal is engineered to be flexible because it had to be.
+* You don't have to adopt it all at once, for everyone, for every user experience in your portal. MyUW variously implemented it as opt-in, opt-out, at certain hostnames, for certain identities, for certain experiences within MyUW. It's been a long walk using the new technology for more and more experiences, and we're still using the traditional uPortal rendering pipeline to render some maximized portlet user experiences. `uPortal home` is engineered to be flexible because it had to be.
 * You don't have to stay stuck on AngularJS 1. We too want to migrate forward to AngularJS2, when time and technology allow.
 
 
 [Andrew Petro](http://apetro.ghost.io/)
 
 
-[AngularJS-portal]: https://github.com/UW-Madison-DoIT/angularjs-portal
+[uPortal home]: https://github.com/uPortal-project/uportal-home
 [KeyValueStore]: https://github.com/UW-Madison-DoIT/KeyValueStore
 [rest-proxy]: https://github.com/UW-Madison-DoIT/rest-proxy
 [Material Design]: https://material.google.com/

--- a/_posts/uportal/2017-01-19-myuw-2016.md
+++ b/_posts/uportal/2017-01-19-myuw-2016.md
@@ -31,7 +31,7 @@ Progress included:
 
 ### uw-frame
 
-MyUW shipped 22 [releases of uw-frame][uw-frame releases] in 2016, from verion 2.0.1 to 3.0.3. [uw-frame][] is the framework in which we develop angularjs-portal. uw-frame is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
+MyUW shipped 22 [releases of uw-frame][uw-frame releases] in 2016, from version 2.0.1 to 3.0.3. [uw-frame][] is the framework in which we develop angularjs-portal. uw-frame is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
 
 + adopted [Material Design][]
 + improved theme support

--- a/_posts/uportal/2017-01-19-myuw-2016.md
+++ b/_posts/uportal/2017-01-19-myuw-2016.md
@@ -7,6 +7,9 @@ tags:       [uPortal]
 
 MyUW had a great 2016. This post summarizes some highlights.
 
+Edits: 
++ adjusted to reflect the new name `uPortal app framework` and new repository location for what was previously known as `uw-frame`
+
 ## Open source software products
 
 MyUW develops several free and open source products in the course of delivering MyUW.
@@ -29,14 +32,14 @@ Progress included:
 + documented
 
 
-### uw-frame
+### uPortal app framework
 
-MyUW shipped 22 [releases of uw-frame][uw-frame releases] in 2016, from version 2.0.1 to 3.0.3. [uw-frame][] is the framework in which we develop angularjs-portal. uw-frame is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
+MyUW shipped 22 [releases of uPortal app framework][uPortal app framework releases] in 2016, from version 2.0.1 to 3.0.3. [uPortal app framework][] is the framework in which we develop angularjs-portal. uPortal app framework is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
 
 + adopted [Material Design][]
 + improved theme support
 + handled session timeouts proactively
-+ cleaned up the way uw-frame is adopted in frame-based apps
++ cleaned up the way uPortal app framework is adopted in frame-based apps
 + sourced dependencies from CDNs
 
 ### microservices
@@ -89,6 +92,6 @@ PS: Other ways to consume this content:
 [rest-proxy]: https://github.com/UW-Madison-DoIT/rest-proxy
 [rssToJson]: https://github.com/UW-Madison-DoIT/rssToJson
 [token-crypt]: https://github.com/UW-Madison-DoIT/token-crypt
-[uw-frame releases]: https://github.com/UW-Madison-DoIT/uw-frame/releases
-[uw-frame]: https://github.com/UW-Madison-DoIT/uw-frame
+[uPortal app framework releases]: https://github.com/uPortal-project/uportal-app-framework/releases
+[uPortal app framework]: https://github.com/uPortal-project/uportal-app-framework
 [on the MyUW build process]: https://apereo.github.io/2016/09/15/myuw-build-now-and-future/

--- a/_posts/uportal/2017-01-19-myuw-2016.md
+++ b/_posts/uportal/2017-01-19-myuw-2016.md
@@ -9,14 +9,15 @@ MyUW had a great 2016. This post summarizes some highlights.
 
 Edits: 
 + adjusted to reflect the new name `uPortal app framework` and new repository location for what was previously known as `uw-frame`
++ adjusted to reflect the new name `uPortal home` and new repository location for what was previously known as `AngularJS-portal`
 
 ## Open source software products
 
 MyUW develops several free and open source products in the course of delivering MyUW.
 
-### [AngularJS-portal][]
+### [uPortal home][]
 
-[MyUW][] shipped 20 [releases of AngularJS-portal][angularjs-portal releases] in 2016. [AngularJS-portal][] is an alternative front end for uPortal.
+[MyUW][] shipped 20 [releases of uPortal home][uPortal home releases] in 2016. [uPortal home][] is an alternative front end for uPortal.
 
 Progress included:
 
@@ -34,7 +35,7 @@ Progress included:
 
 ### uPortal app framework
 
-MyUW shipped 22 [releases of uPortal app framework][uPortal app framework releases] in 2016, from version 2.0.1 to 3.0.3. [uPortal app framework][] is the framework in which we develop angularjs-portal. uPortal app framework is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
+MyUW shipped 22 [releases of uPortal app framework][uPortal app framework releases] in 2016, from version 2.0.1 to 3.0.3. [uPortal app framework][] is the framework in which we develop uPortal home. uPortal app framework is also the framework in which we and other groups in the University of Wisconsin develop applications for inclusion in the portal. Writing a frame-based app is conceptually an alternative to writing a Java Portlet.
 
 + adopted [Material Design][]
 + improved theme support
@@ -82,8 +83,8 @@ PS: Other ways to consume this content:
 + [in January 2017 newsletter as posted to announcements email list](https://groups.google.com/a/apereo.org/d/msg/announcements/gEubp0iejn4/IMyt-AfjBQAJ) (Alas, no hyperlinks).
 + [in January 2017 newsletter as posted in a Word doc](https://www.apereo.org/sites/default/files/Newsletters/Images%20for%20Newsletter%20Articles/January2017Apereo%20NL.pdf) (Alas, no hyperlinks).
 
-[angularjs-portal releases]: https://github.com/UW-Madison-DoIT/angularjs-portal/releases
-[AngularJS-portal]: https://github.com/UW-Madison-DoIT/angularjs-portal
+[uPortal home releases]: https://github.com/uPortal-project/uportal-home/releases
+[uPortal home]: https://github.com/uPortal-project/uportal-home
 [Apereo WebProxy Portlet]: https://github.com/Jasig/WebproxyPortlet
 [KeyValueStore]: https://github.com/UW-Madison-DoIT/KeyValueStore
 [lti-proxy]: https://github.com/UW-Madison-DoIT/lti-proxy

--- a/_posts/uportal/2017-06-20-myuw-2016-numbers.md
+++ b/_posts/uportal/2017-06-20-myuw-2016-numbers.md
@@ -238,8 +238,8 @@ MyUW is
 [scholarships-at-uw-madison]: https://public.my.wisc.edu/web/apps/details/scholarships-at-uw-madison
 [token-crypt]: https://github.com/UW-Madison-DoIT/token-crypt
 [uw-badger-headlines]: https://public.my.wisc.edu/web/apps/details/uw-badger-headlines
-[uw-frame releases]: https://github.com/UW-Madison-DoIT/uw-frame/releases
-[uw-frame]: https://github.com/UW-Madison-DoIT/uw-frame
+[uPortal app framework releases]: https://github.com/uPortal-project/uportal-app-framework/releases
+[uPortal app framework]: https://github.com/uPortal-project/uportal-app-framework
 [uw-madison-working-at-uw]: https://public.my.wisc.edu/web/apps/details/uw-madison-working-at-uw
 [uwp-news-feed]: https://public.my.wisc.edu/web/apps/details/uwp-news-feed
 [uwrf-employee-resources]: https://public.my.wisc.edu/web/apps/details/uwrf-employee-resources

--- a/_posts/uportal/2017-06-20-myuw-2016-numbers.md
+++ b/_posts/uportal/2017-06-20-myuw-2016-numbers.md
@@ -207,8 +207,8 @@ MyUW is
 
 [Andrew Petro](http://apetro.ghost.io/)
 
-[angularjs-portal releases]: https://github.com/UW-Madison-DoIT/angularjs-portal/releases
-[AngularJS-portal]: https://github.com/UW-Madison-DoIT/angularjs-portal
+[uPortal home releases]: https://github.com/uPortal-project/uportal-home/releases
+[uPortal home]: https://github.com/uPortal-project/uportal-home
 [Apereo Board of Directors]: https://www.apereo.org/content/leadership
 [Apereo WebProxy Portlet]: https://github.com/Jasig/WebproxyPortlet
 [campus-news]: https://public.my.wisc.edu/web/apps/details/campus-news


### PR DESCRIPTION
Reflect that

+ `uw-frame` is now `uPortal app framework`
+ `AngularJS-portal` is now `uPortal home` (move not yet executed)