### PR TITLE
fix: clarify that Apereo is not 100% open

### DIFF
--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ tags: about
 
 Formed in 2012, the [Apereo Foundation](https://www.apereo.org) is a vibrant and value-driven organization. Apereo has a noteworthy history celebrating two strong organizations, the Sakai Foundation and Jasig. Apereo is a community built around openness, inclusivity, collaboration and innovation. The mission of Apereo is to help educational organizations “collaborate to foster, develop, and sustain open technologies and innovation to support learning, teaching, and research." 
 
-Apereo is 100% open.
+Apereo projects are 100% open.
 
 ### About Blog
 


### PR DESCRIPTION
It's just factually untrue that "Apereo is 100% open.", so don't say it that way.

A couple of off-hand examples:

+ There are closed email lists, [including `projects@`](https://groups.google.com/a/apereo.org/d/msg/open/GNtB1MGvZK4/O3ZT83AzBwAJ)
+ The Board meetings are closed to the public and [sometimes go into Executive Session](https://www.apereo.org/sites/default/files/meeting_minutes/2017/Apereo%20Board%20Minutes%20-%20Dec%202017%20-%20002.pdf) for which even minutes are not available.
+ Incubating projects may not have source code publicly available, as is the case (so far?) with an incubating notifications bus.

All of this not-entirely-open-ness might be justified and prudent -- but it nonetheless factually bumps the openness below 100%. Let's not say things that aren't true.

Therefore nuance the "About" page to say that Apereo *projects* are 100% open, which maybe still isn't entirely factually correct (is the incubating notifications bus an Apereo project? Is it "100% open" even though the source code is not available?), but is at least closer to the truth.
