### PR TITLE
Update 2018-06-19-cas53webflow-extensions.md

### DIFF
--- a/_posts/cas/2018-06-19-cas53webflow-extensions.md
+++ b/_posts/cas/2018-06-19-cas53webflow-extensions.md
@@ -68,11 +68,16 @@ public class SomethingConfiguration implements CasWebflowExecutionPlanConfigurer
 
     @ConditionalOnMissingBean(name = "somethingWebflowConfigurer")
     @Bean
-    @DependsOn("defaultWebflowConfigurer")
     public CasWebflowConfigurer somethingWebflowConfigurer() {
         return new SomethingWebflowConfigurer(flowBuilderServices, loginFlowDefinitionRegistry,
             applicationContext, casProperties);
     }
+    
+    @Override
+    public void configureWebflowExecutionPlan(final CasWebflowExecutionPlan plan) {
+        plan.registerWebflowConfigurer(somethingWebflowConfigurer());
+    }
+    
 }
 ```
 


### PR DESCRIPTION
Add missing 'configureWebflowExecutionPlan override into the SomethingConfiguration example (without which your custom webflow never gets considered for inclusion).
This merely reflects the official documentation here: https://apereo.github.io/cas/5.3.x/installation/Webflow-Customization-Extensions.html