### PR TITLE
Posts: Minor correction to the SAML2 idP metadata overrides post

### DIFF
--- a/_posts/cas/2019-12-16-cas62x-saml2-metadata-service.md
+++ b/_posts/cas/2019-12-16-cas62x-saml2-metadata-service.md
@@ -70,12 +70,12 @@ SAML2 service provider in a `SAML-1.json` file:
 # Overrides
 
 Let's say our service provider wanted to use a different set of signing keys, encryption keys or metadata completely separate from the global SAML2 
-artifacts listed above. Since we are using the filesystem, these overriding artifacts are expected to be found at `/etc/cas/config/saml/Example`. The formula is, you should create a directory using the name of your service definition (i.e. `Example`) and this directly should be created inside the canonical global SAML2 metadata directory. 
+artifacts listed above. Since we are using the filesystem, these overriding artifacts are expected to be found at `/etc/cas/config/saml/Example-1`. The formula is, you should create a directory using the name of your service definition and its numerical identifier (i.e. `Example-1`) and this directly should be created inside the canonical global SAML2 metadata directory. 
 
 ```bash
 $ tree /etc/cas/saml/
 /etc/cas/saml/
-├── Example
+├── Example-1
 │   ├── idp-encryption.crt
 │   ├── idp-encryption.key
 │   ├── idp-metadata.xml


### PR DESCRIPTION
In the example given in the aforementioned blog post, it's incorrectly
mentioned that only the service's name is required. As shown in [here](https://github.com/apereo/cas/blob/e3fd1dacfa34e59f42f23182380571cc070a254f/support/cas-server-support-saml-idp-core/src/main/java/org/apereo/cas/support/saml/idp/metadata/locator/FileSystemSamlIdPMetadataLocator.java#L37-L43), CAS
itself looks up to the per-service directory with the following pattern:
`<service_name>-<service_numeric_identifier>`.

I'll open a PR to change CAS' docs too, unless we change the code itself, to reflect what's in the docs